### PR TITLE
new: properly use driverkit v0.15.0 builder images while building.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
 GO ?= go
 output ?= dbg-go
 TEST_FLAGS ?= -v -race -tags=test_all
+LDFLAGS := -X github.com/falcosecurity/driverkit/pkg/driverbuilder/builder.defaultImageTag=v0.15.0
 
 .PHONY: build
 build: ${output}
 
 .PHONY: ${output}
 ${output}:
-	$(GO) build -o $@
+	CGO_ENABLED=0 $(GO) build -ldflags '${LDFLAGS}' -o $@
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -125,3 +125,11 @@ Using `goreleaser`, multiple artifacts are attached to each github release; amon
 
 
 > **NOTE:** all commands that require s3 write access, need a proper `--aws-profile` to be passed.
+
+## Bumping driverkit
+
+To bump driverkit, you just need:
+```shell
+go get github.com/falcosecurity/driverkit@vX.Y.Z
+```
+and then update Makefile LDFLAGS defaultImageTag to same version.

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -87,19 +87,19 @@ func buildConfig(client *s3utils.Client, opts Options, redirectErrorsF *os.File,
 		if ro.Output.Module != "" {
 			moduleName := filepath.Base(ro.Output.Module)
 			if client.HeadDriver(opts.Options, driverVersion, moduleName) {
-				logger.Info("output module already exists inside S3 bucket - skipping", "path", ro.Output.Module)
+				logger.Info("output module already exists inside S3 bucket - skipping")
 				ro.Output.Module = "" // disable module build
 			}
 		}
 		if ro.Output.Probe != "" {
 			probeName := filepath.Base(ro.Output.Probe)
 			if client.HeadDriver(opts.Options, driverVersion, probeName) {
-				logger.Info("output probe already exists inside S3 bucket - skipping", "path", ro.Output.Probe)
+				logger.Info("output probe already exists inside S3 bucket - skipping")
 				ro.Output.Probe = "" // disable probe build
 			}
 		}
 		if ro.Output.Module == "" && ro.Output.Probe == "" {
-			logger.Info("drivers already available on remote, skipping")
+			logger.Info("drivers already available on S3 bucket, skipping build")
 			return nil // nothing to do
 		}
 	}


### PR DESCRIPTION
Also, properly build a static dbg-go!