### PR TITLE
chore(build): use GOEXPERIMENT=loopvar in tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ clean:
 
 .PHONY: test
 test:
-	$(GO) test ${TEST_FLAGS} ./...
+	GOEXPERIMENT=loopvar $(GO) test ${TEST_FLAGS} ./...
 
 .PHONY: bump-driverkit
 bump-driverkit:


### PR DESCRIPTION
https://go.dev/blog/loopvar-preview
Enforce at least during tests, so that stupid bugs are caught.